### PR TITLE
Fix test for Vector{Any}

### DIFF
--- a/src/SeDuMi.jl
+++ b/src/SeDuMi.jl
@@ -20,9 +20,9 @@ end
 function Cone(
     f::Real,
     l::Real,
-    q::Vector{<:Real},
-    r::Vector{<:Real},
-    s::Vector{<:Real},
+    q::Vector,
+    r::Vector,
+    s::Vector,
 )
     return Cone(f, l, q, r, s, Float64[], Float64[], Float64[])
 end

--- a/src/SeDuMi.jl
+++ b/src/SeDuMi.jl
@@ -17,13 +17,7 @@ mutable struct Cone
     ycomplex::Vector{Float64} #list of constraints on A*x that should also act on the imaginary part
     xcomplex::Vector{Float64} #list of components of f,l,q,r blocks allowed to be complex
 end
-function Cone(
-    f::Real,
-    l::Real,
-    q::Vector,
-    r::Vector,
-    s::Vector,
-)
+function Cone(f::Real, l::Real, q::Vector, r::Vector, s::Vector)
     return Cone(f, l, q, r, s, Float64[], Float64[], Float64[])
 end
 Cone(f::Real, l::Real) = Cone(f, l, Float64[], Float64[], Float64[])


### PR DESCRIPTION
Fix tests for change of https://github.com/jump-dev/SeDuMi.jl/pull/24
@araujoms The vectors created here
https://github.com/jump-dev/SeDuMi.jl/blob/b1b5534c3b66f31b5874d32c8f9265110cfc606a/test/sdp.jl#L25
are `Vector{Any}` so `Vector{<:Real}` won't work