### PR TITLE
bump compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-MATLAB = "0.7.3, 0.8"
+MATLAB = "0.7.3 - 0.9"
 MathOptInterface = "1.1"
 julia = "1.6"
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -52,13 +52,15 @@ function test_runtests()
                 MOI.SolverVersion,
             ],
         ),
-        exclude = String[
+        exclude = [
             # Expected test failures:
             #   ArgumentError: The number of constraints must be greater than 0
             "test_attribute_RawStatusString",
             "test_attribute_SolveTimeSec",
             "test_objective_ObjectiveFunction_blank",
             "test_solve_TerminationStatus_DUAL_INFEASIBLE",
+            # Out of memory.
+            "test_conic_empty_matrix",
             # TODO investigate
             #  Expression: ≈(MOI.get(model, MOI.ConstraintPrimal(), c2), 0, atol = atol, rtol = rtol)
             #  Evaluated: 1.7999998823840366 ≈ 0 (atol=0.0001, rtol=0.0001)
@@ -74,12 +76,12 @@ function test_runtests()
             "test_conic_SecondOrderCone_no_initial_bound",
             # FIXME The objective has wrong sign
             # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
-            "test_unbounded_MAX_SENSE",
-            "test_unbounded_MAX_SENSE_offset",
+            r"^test_unbounded_MAX_SENSE$",
+            r"^test_unbounded_MAX_SENSE_offset$",
             # FIXME The objective is wrong
             # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
-            "test_unbounded_MIN_SENSE",
-            "test_unbounded_MIN_SENSE_offset",
+            r"^test_unbounded_MIN_SENSE$",
+            r"^test_unbounded_MIN_SENSE_offset$",
         ],
     )
     return


### PR DESCRIPTION
Bump compat to accept new version of MATLAB.jl. Tests pass. The one I added to the excluded list already errored on the previous version.