### PR TITLE
Relax tolerance

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -43,8 +43,8 @@ function test_runtests()
     MOI.Test.runtests(
         model,
         MOI.Test.Config(
-            rtol = 1e-4,
-            atol = 1e-4,
+            rtol = 5e-3,
+            atol = 5e-3,
             exclude = Any[
                 MOI.ConstraintBasisStatus,
                 MOI.VariableBasisStatus,


### PR DESCRIPTION
Before this PR I had:
https://github.com/jump-dev/SeDuMi.jl/pull/31#issuecomment-2809053502
After this PR, on the same machine:
```julia
julia> versioninfo()
Julia Version 1.10.2
Commit bd47eca2c8a (2024-03-01 10:14 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 36 × Intel(R) Xeon(R) W-2295 CPU @ 3.00GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-15.0.7 (ORCJIT, cascadelake)
Threads: 1 default, 0 interactive, 1 GC (on 36 virtual cores)

julia> include("test/runtests.jl");
Test Summary:              | Pass  Total  Time
Linear Programming example |    7      7  2.1s
Test Summary:                    | Pass  Total  Time
Semidefinite Programming example |   10     10  0.6s
Test Summary: | Pass  Total  Time
test_options  |    1      1  0.0s
>> Warning: Rank deficient, rank = 1, tol =  4.615110e-14. 
> In sedumi (line 272)
 
>> Warning: Rank deficient, rank = 1, tol =  4.615110e-14. 
> In sedumi (line 272)
 
Test Summary: | Pass  Total     Time
test_runtests | 4070   4070  5m34.6s
Test Summary:    | Pass  Total  Time
test_solver_name |    1      1  0.0s
```